### PR TITLE
feat: trace debugging with X-DataKit-Debug-Trace header 

### DIFF
--- a/datakit-filter/src/config.rs
+++ b/datakit-filter/src/config.rs
@@ -123,6 +123,8 @@ impl<'a> Deserialize<'a> for UserNodeConfig {
 #[derive(Deserialize, Default)]
 pub struct UserConfig {
     nodes: Vec<UserNodeConfig>,
+    #[serde(default)]
+    debug: bool,
 }
 
 struct NodeInfo {
@@ -135,6 +137,7 @@ pub struct Config {
     node_list: Vec<NodeInfo>,
     node_names: Vec<String>,
     graph: DependencyGraph,
+    debug: bool,
 }
 
 impl Config {
@@ -179,6 +182,7 @@ impl Config {
                     node_list,
                     node_names,
                     graph,
+                    debug: user_config.debug,
                 })
             }
             Err(err) => Err(format!(
@@ -189,8 +193,18 @@ impl Config {
         }
     }
 
+    pub fn debug(&self) -> bool {
+        self.debug
+    }
+
     pub fn get_node_names(&self) -> &Vec<String> {
         &self.node_names
+    }
+
+    pub fn node_types(&self) -> impl Iterator<Item = (&str, &str)> {
+        self.node_list
+            .iter()
+            .map(|info| (info.name.as_ref(), info.node_type.as_ref()))
     }
 
     pub fn get_graph(&self) -> &DependencyGraph {

--- a/datakit-filter/src/data.rs
+++ b/datakit-filter/src/data.rs
@@ -37,6 +37,19 @@ impl Payload {
         }
     }
 
+    pub fn to_json(&self) -> Result<serde_json::Value, ()> {
+        match &self {
+            Payload::Json(value) => Ok(value.clone()),
+            Payload::Raw(vec) => {
+                if let Ok(s) = std::str::from_utf8(vec) {
+                    return serde_json::to_value(s).or(Err(()));
+                }
+
+                Err(())
+            }
+        }
+    }
+
     pub fn to_bytes(&self) -> Vec<u8> {
         match &self {
             Payload::Json(value) => {

--- a/datakit-filter/src/debug.rs
+++ b/datakit-filter/src/debug.rs
@@ -1,0 +1,151 @@
+use crate::config::Config;
+use crate::data::{Payload, State};
+use serde::Serialize;
+use std::collections::HashMap;
+
+pub enum RunMode {
+    Run,
+    Resume,
+}
+
+pub enum DataMode {
+    Done,
+    Waiting,
+}
+
+struct RunOperation {
+    node_name: String,
+    node_type: String,
+    action: RunMode,
+}
+
+struct SetOperation {
+    node_name: String,
+    data_type: String,
+    status: DataMode,
+    value: Option<serde_json::Value>,
+}
+
+enum Operation {
+    Run(RunOperation),
+    Set(SetOperation),
+}
+
+pub struct Debug {
+    trace: bool,
+    operations: Vec<Operation>,
+    node_types: HashMap<String, String>,
+}
+
+impl State {
+    fn to_data_mode(&self) -> DataMode {
+        match self {
+            State::Done(_) => DataMode::Done,
+            State::Waiting(_) => DataMode::Waiting,
+        }
+    }
+}
+
+impl Debug {
+    pub fn new(config: &Config) -> Debug {
+        let mut node_types = HashMap::new();
+        for (name, node_type) in config.node_types() {
+            node_types.insert(name.to_string(), node_type.to_string());
+        }
+
+        Debug {
+            node_types,
+            trace: false,
+            operations: vec![],
+        }
+    }
+
+    pub fn set_data(&mut self, name: &str, state: &State) {
+        if self.trace {
+            let (data_type, value) = match state {
+                State::Done(d) => {
+                    if let Some(p) = d {
+                        let dt = p.content_type().unwrap_or("raw").to_string();
+                        let v = p.to_json().ok();
+
+                        (dt, v)
+                    } else {
+                        ("none".to_string(), None)
+                    }
+                }
+                State::Waiting(_) => ("waiting".to_string(), None),
+            };
+
+            self.operations.push(Operation::Set(SetOperation {
+                node_name: name.to_string(),
+                data_type,
+                status: state.to_data_mode(),
+                value,
+            }));
+        }
+    }
+
+    pub fn run(&mut self, name: &str, _args: &[Option<&Payload>], state: &State, action: RunMode) {
+        if self.trace {
+            let node_type = self.node_types.get(name).expect("node exists");
+
+            self.operations.push(Operation::Run(RunOperation {
+                action,
+                node_name: name.to_string(),
+                node_type: node_type.to_string(),
+            }));
+
+            self.set_data(name, state);
+        }
+    }
+
+    pub fn set_tracing(&mut self, enable: bool) {
+        self.trace = enable;
+    }
+
+    pub fn is_tracing(&self) -> bool {
+        self.trace
+    }
+
+    pub fn get_trace(&self) -> String {
+        #[derive(Serialize)]
+        struct TraceAction<'a> {
+            action: &'static str,
+            name: &'a str,
+            r#type: Option<&'a str>,
+            value: Option<&'a serde_json::Value>,
+        }
+
+        let mut actions: Vec<TraceAction> = vec![];
+
+        for op in self.operations.iter() {
+            actions.push(match op {
+                Operation::Run(run) => TraceAction {
+                    action: match run.action {
+                        RunMode::Run => "run",
+                        RunMode::Resume => "resume",
+                    },
+                    name: &run.node_name,
+                    r#type: Some(&run.node_type),
+                    value: None,
+                },
+                Operation::Set(set) => match set.status {
+                    DataMode::Done => TraceAction {
+                        action: "value",
+                        name: &set.node_name,
+                        r#type: Some(&set.data_type),
+                        value: set.value.as_ref(),
+                    },
+                    DataMode::Waiting => TraceAction {
+                        action: "wait",
+                        name: &set.node_name,
+                        r#type: None,
+                        value: None,
+                    },
+                },
+            });
+        }
+
+        serde_json::json!(actions).to_string()
+    }
+}

--- a/datakit-filter/src/filter.rs
+++ b/datakit-filter/src/filter.rs
@@ -110,7 +110,9 @@ impl DataKitFilter {
                         .expect("self.nodes doesn't match self.node_names");
                     if let Some(inputs) = self.data.get_inputs_for(name, None) {
                         any_ran = true;
-                        let state = node.run(self, inputs);
+
+                        let state = node.run(self, &inputs);
+
                         if let State::Waiting(_) = state {
                             ret = Action::Pause;
                         }
@@ -145,7 +147,8 @@ impl Context for DataKitFilter {
                     .get_mut(name)
                     .expect("self.nodes doesn't match self.node_names");
                 if let Some(inputs) = self.data.get_inputs_for(name, Some(token_id)) {
-                    let state = node.resume(self, inputs);
+                    let state = node.resume(self, &inputs);
+
                     self.data.set(name, state);
                     break;
                 }

--- a/datakit-filter/src/nodes.rs
+++ b/datakit-filter/src/nodes.rs
@@ -13,11 +13,11 @@ pub mod template;
 pub type NodeMap = BTreeMap<String, Box<dyn Node>>;
 
 pub trait Node {
-    fn run(&mut self, _ctx: &dyn HttpContext, _inputs: Vec<Option<&Payload>>) -> State {
+    fn run(&mut self, _ctx: &dyn HttpContext, _inputs: &[Option<&Payload>]) -> State {
         Done(None)
     }
 
-    fn resume(&mut self, _ctx: &dyn HttpContext, _inputs: Vec<Option<&Payload>>) -> State {
+    fn resume(&mut self, _ctx: &dyn HttpContext, _inputs: &[Option<&Payload>]) -> State {
         Done(None)
     }
 

--- a/datakit-filter/src/nodes/call.rs
+++ b/datakit-filter/src/nodes/call.rs
@@ -36,7 +36,7 @@ pub struct Call {
 }
 
 impl Node for Call {
-    fn run(&mut self, ctx: &dyn HttpContext, inputs: Vec<Option<&Payload>>) -> State {
+    fn run(&mut self, ctx: &dyn HttpContext, inputs: &[Option<&Payload>]) -> State {
         log::debug!("call: run");
 
         let body = inputs.first().unwrap_or(&None);
@@ -93,7 +93,7 @@ impl Node for Call {
         }
     }
 
-    fn resume(&mut self, ctx: &dyn HttpContext, _inputs: Vec<Option<&Payload>>) -> State {
+    fn resume(&mut self, ctx: &dyn HttpContext, _inputs: &[Option<&Payload>]) -> State {
         log::debug!("call: resume");
 
         let r = if let Some(body) = ctx.get_http_call_response_body(0, usize::MAX) {

--- a/datakit-filter/src/nodes/response.rs
+++ b/datakit-filter/src/nodes/response.rs
@@ -27,7 +27,7 @@ pub struct Response {
 }
 
 impl Node for Response {
-    fn run(&mut self, ctx: &dyn HttpContext, inputs: Vec<Option<&Payload>>) -> State {
+    fn run(&mut self, ctx: &dyn HttpContext, inputs: &[Option<&Payload>]) -> State {
         let body = inputs.first().unwrap_or(&None);
         let headers = inputs.get(1).unwrap_or(&None);
 

--- a/datakit-filter/src/nodes/template.rs
+++ b/datakit-filter/src/nodes/template.rs
@@ -46,7 +46,7 @@ impl Template<'_> {
 }
 
 impl Node for Template<'_> {
-    fn run(&mut self, _ctx: &dyn HttpContext, inputs: Vec<Option<&Payload>>) -> State {
+    fn run(&mut self, _ctx: &dyn HttpContext, inputs: &[Option<&Payload>]) -> State {
         log::debug!("template: run - inputs: {:?}", inputs);
 
         let mut vs = Vec::new();

--- a/docs/datakit.md
+++ b/docs/datakit.md
@@ -52,4 +52,20 @@ or arrays of strings if there are multiple instances of the same header.
 The `_body` nodes produce either raw strings or JSON objects, depending on their corresponding
 `Content-Type` values.
 
+## Debugging
+
+DataKit includes support for debugging your configuration.
+
+### Execution tracing
+
+By setting the `X-DataKit-Debug-Trace` header, DataKit records the execution
+flow and the values of intermediate nodes, reporting the output in the request
+body in JSON format.
+
+If the debug header value is set to `0`, `false`, or `off`, this is equivalent to
+unsetting the debug header: tracing will not happen and execution will run
+as normal. Any other value will enable debug tracing.
+
+---
+
 [serde-json]: https://docs.rs/serde_json/latest/serde_json/


### PR DESCRIPTION
By setting the `X-DataKit-Debug-Trace` header, DataKit records the execution flow and the values of intermediate nodes, reporting the output in the request body in JSON format.

If the debug header value is set to `0`, `false`, or `off`, this is equivalent to unsetting the debug header: tracing will not happen and execution will run as normal. Any other value will enable debug tracing.

