### PR TITLE
refactor(nodes): remove need for mutable reference

### DIFF
--- a/datakit-filter/src/nodes.rs
+++ b/datakit-filter/src/nodes.rs
@@ -13,11 +13,11 @@ pub mod template;
 pub type NodeMap = BTreeMap<String, Box<dyn Node>>;
 
 pub trait Node {
-    fn run(&mut self, _ctx: &dyn HttpContext, _inputs: &[Option<&Payload>]) -> State {
+    fn run(&self, _ctx: &dyn HttpContext, _inputs: &[Option<&Payload>]) -> State {
         Done(None)
     }
 
-    fn resume(&mut self, _ctx: &dyn HttpContext, _inputs: &[Option<&Payload>]) -> State {
+    fn resume(&self, _ctx: &dyn HttpContext, _inputs: &[Option<&Payload>]) -> State {
         Done(None)
     }
 

--- a/datakit-filter/src/nodes/response.rs
+++ b/datakit-filter/src/nodes/response.rs
@@ -27,7 +27,7 @@ pub struct Response {
 }
 
 impl Node for Response {
-    fn run(&mut self, ctx: &dyn HttpContext, inputs: &[Option<&Payload>]) -> State {
+    fn run(&self, ctx: &dyn HttpContext, inputs: &[Option<&Payload>]) -> State {
         let body = inputs.first().unwrap_or(&None);
         let headers = inputs.get(1).unwrap_or(&None);
 

--- a/datakit-filter/src/nodes/template.rs
+++ b/datakit-filter/src/nodes/template.rs
@@ -46,7 +46,7 @@ impl Template<'_> {
 }
 
 impl Node for Template<'_> {
-    fn run(&mut self, _ctx: &dyn HttpContext, inputs: &[Option<&Payload>]) -> State {
+    fn run(&self, _ctx: &dyn HttpContext, inputs: &[Option<&Payload>]) -> State {
         log::debug!("template: run - inputs: {:?}", inputs);
 
         let mut vs = Vec::new();


### PR DESCRIPTION
This removes the mutable reference from `Node.run()` and `Node.resume()`. The one node that needed the mutable reference (`call`) was updated to use a [RwLock](https://doc.rust-lang.org/std/sync/struct.RwLock.html) for its state.

I also replaced `DataKitFilter.node_names` with an `Rc<Config>`, which gets rid of a clone op (we are just cloning a reference which is free).