### PR TITLE
feat(call): support degraded behavior in late responses

### DIFF
--- a/src/filter.rs
+++ b/src/filter.rs
@@ -301,6 +301,10 @@ impl HttpContext for DataKitFilter {
     }
 
     fn on_http_response_body(&mut self, body_size: usize, eof: bool) -> Action {
+        if !eof {
+            return Action::Pause;
+        }
+
         if eof && self.do_service_response_body {
             if let Some(bytes) = self.get_http_response_body(0, body_size) {
                 let content_type = self.get_http_response_header("Content-Type");

--- a/src/nodes.rs
+++ b/src/nodes.rs
@@ -25,6 +25,14 @@ pub trait Node {
 
 pub trait NodeConfig {
     fn as_any(&self) -> &dyn Any;
+
+    fn default_inputs(&self) -> Option<Vec<String>> {
+        None
+    }
+
+    fn default_outputs(&self) -> Option<Vec<String>> {
+        None
+    }
 }
 
 pub trait NodeFactory: Send {

--- a/src/nodes.rs
+++ b/src/nodes.rs
@@ -13,8 +13,23 @@ pub mod template;
 
 pub type NodeMap = BTreeMap<String, Box<dyn Node>>;
 
+#[allow(clippy::enum_variant_names)]
+#[derive(PartialEq, Clone, Copy)]
+pub enum FilterPhase {
+    HttpRequestHeaders,
+    HttpRequestBody,
+    HttpResponseHeaders,
+    HttpResponseBody,
+    HttpCallResponse,
+}
+
 pub trait Node {
-    fn run(&self, _ctx: &dyn HttpContext, _inputs: &[Option<&Payload>]) -> State {
+    fn run(
+        &self,
+        _ctx: &dyn HttpContext,
+        _inputs: &[Option<&Payload>],
+        _phase: FilterPhase,
+    ) -> State {
         Done(None)
     }
 

--- a/src/nodes/call.rs
+++ b/src/nodes/call.rs
@@ -9,7 +9,7 @@ use url::Url;
 use crate::config::get_config_value;
 use crate::data;
 use crate::data::{Payload, State, State::*};
-use crate::nodes::{Node, NodeConfig, NodeFactory};
+use crate::nodes::{FilterPhase, Node, NodeConfig, NodeFactory};
 
 #[derive(Clone, Debug)]
 pub struct CallConfig {
@@ -33,7 +33,7 @@ pub struct Call {
 }
 
 impl Node for Call {
-    fn run(&self, ctx: &dyn HttpContext, inputs: &[Option<&Payload>]) -> State {
+    fn run(&self, ctx: &dyn HttpContext, inputs: &[Option<&Payload>], _: FilterPhase) -> State {
         log::debug!("call: run");
 
         let body = inputs.first().unwrap_or(&None);

--- a/src/nodes/jq.rs
+++ b/src/nodes/jq.rs
@@ -8,7 +8,7 @@ use std::collections::BTreeMap;
 
 use crate::config::get_config_value;
 use crate::data::{Payload, State};
-use crate::nodes::{Node, NodeConfig, NodeFactory};
+use crate::nodes::{FilterPhase, Node, NodeConfig, NodeFactory};
 
 #[derive(Clone, Debug)]
 pub struct JqConfig {
@@ -175,7 +175,7 @@ impl Jq {
 }
 
 impl Node for Jq {
-    fn run(&self, _ctx: &dyn HttpContext, inputs: &[Option<&Payload>]) -> State {
+    fn run(&self, _ctx: &dyn HttpContext, inputs: &[Option<&Payload>], _: FilterPhase) -> State {
         match self.exec(inputs) {
             Ok(mut results) => {
                 State::Done(match results.len() {

--- a/src/nodes/response.rs
+++ b/src/nodes/response.rs
@@ -19,6 +19,10 @@ impl NodeConfig for ResponseConfig {
     fn as_any(&self) -> &dyn Any {
         self
     }
+
+    fn default_outputs(&self) -> Option<Vec<String>> {
+        Some(vec!["response_body".to_string()])
+    }
 }
 
 #[derive(Clone)]

--- a/src/nodes/response.rs
+++ b/src/nodes/response.rs
@@ -6,7 +6,7 @@ use std::collections::BTreeMap;
 use crate::config::get_config_value;
 use crate::data;
 use crate::data::{Payload, State, State::*};
-use crate::nodes::{Node, NodeConfig, NodeFactory};
+use crate::nodes::{FilterPhase, Node, NodeConfig, NodeFactory};
 
 #[derive(Clone, Debug)]
 pub struct ResponseConfig {
@@ -31,7 +31,7 @@ pub struct Response {
 }
 
 impl Node for Response {
-    fn run(&self, ctx: &dyn HttpContext, inputs: &[Option<&Payload>]) -> State {
+    fn run(&self, ctx: &dyn HttpContext, inputs: &[Option<&Payload>], phase: FilterPhase) -> State {
         let body = inputs.first().unwrap_or(&None);
         let headers = inputs.get(1).unwrap_or(&None);
 

--- a/src/nodes/response.rs
+++ b/src/nodes/response.rs
@@ -48,7 +48,13 @@ impl Node for Response {
             Err(e) => return Fail(Some(Payload::Error(e))),
         };
 
-        ctx.send_http_response(self.config.status, headers_vec, body_slice.as_deref());
+        if phase == FilterPhase::HttpResponseBody {
+            if let Some(b) = body_slice {
+                ctx.set_http_response_body(0, b.len(), &b);
+            }
+        } else {
+            ctx.send_http_response(self.config.status, headers_vec, body_slice.as_deref());
+        }
 
         Done(None)
     }

--- a/src/nodes/template.rs
+++ b/src/nodes/template.rs
@@ -6,7 +6,7 @@ use std::collections::BTreeMap;
 
 use crate::config::get_config_value;
 use crate::data::{Payload, State};
-use crate::nodes::{Node, NodeConfig, NodeFactory};
+use crate::nodes::{FilterPhase, Node, NodeConfig, NodeFactory};
 
 #[derive(Clone, Debug)]
 pub struct TemplateConfig {
@@ -46,7 +46,7 @@ impl Template<'_> {
 }
 
 impl Node for Template<'_> {
-    fn run(&self, _ctx: &dyn HttpContext, inputs: &[Option<&Payload>]) -> State {
+    fn run(&self, _ctx: &dyn HttpContext, inputs: &[Option<&Payload>], _: FilterPhase) -> State {
         log::debug!("template: run - inputs: {:?}", inputs);
 
         let mut vs = Vec::new();


### PR DESCRIPTION
If the `response` node needs the `service_response_body` input, it can only be triggered at the `HttpResponseBody` phase (which in Nginx means `body_filter`). This means that the headers have already been sent, meaning we can't use `ctx.send_http_response`.

By detecting this late phase, we degrade the behavior of the node and only set the response body. More specifically, in those cases the `response` node cannot set headers or a custom status.

See #11.