### PR TITLE
fix(call): support degraded behavior in late responses

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -3,6 +3,21 @@ use std::collections::BTreeMap;
 
 use crate::dependency_graph::DependencyGraph;
 
+#[allow(clippy::enum_variant_names)]
+#[derive(PartialEq, Clone, Copy)]
+pub enum Phase {
+    HttpRequestHeaders,
+    HttpRequestBody,
+    HttpResponseHeaders,
+    HttpResponseBody,
+    HttpCallResponse,
+}
+
+pub struct Input<'a> {
+    pub data: &'a [Option<&'a Payload>],
+    pub phase: Phase,
+}
+
 #[derive(Debug)]
 pub enum Payload {
     Raw(Vec<u8>),

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -301,6 +301,10 @@ impl HttpContext for DataKitFilter {
     }
 
     fn on_http_response_body(&mut self, body_size: usize, eof: bool) -> Action {
+        if !eof {
+            return Action::Pause;
+        }
+
         if eof && self.do_service_response_body {
             if let Some(bytes) = self.get_http_response_body(0, body_size) {
                 let content_type = self.get_http_response_header("Content-Type");

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -8,7 +8,7 @@ mod dependency_graph;
 mod nodes;
 
 use crate::config::Config;
-use crate::data::{Data, Payload, State};
+use crate::data::{Data, Input, Payload, Phase, Phase::*, State};
 use crate::debug::{Debug, RunMode};
 use crate::dependency_graph::DependencyGraph;
 use crate::nodes::{Node, NodeMap};
@@ -157,7 +157,7 @@ impl DataKitFilter {
         self.set_data(name, State::Done(Some(payload)));
     }
 
-    fn run_nodes(&mut self) -> Action {
+    fn run_nodes(&mut self, phase: Phase) -> Action {
         let mut ret = Action::Continue;
 
         loop {
@@ -171,7 +171,11 @@ impl DataKitFilter {
                 if let Some(inputs) = self.data.get_inputs_for(name, None) {
                     any_ran = true;
 
-                    let state = node.run(self as &dyn HttpContext, &inputs);
+                    let input = Input {
+                        data: &inputs,
+                        phase,
+                    };
+                    let state = node.run(self as &dyn HttpContext, &input);
 
                     if let Some(ref mut debug) = self.debug {
                         debug.run(name, &inputs, &state, RunMode::Run);
@@ -209,7 +213,11 @@ impl Context for DataKitFilter {
                 .expect("self.nodes doesn't match self.node_names")
                 .as_ref();
             if let Some(inputs) = self.data.get_inputs_for(name, Some(token_id)) {
-                let state = node.resume(self, &inputs);
+                let input = Input {
+                    data: &inputs,
+                    phase: HttpCallResponse,
+                };
+                let state = node.resume(self, &input);
 
                 if let Some(ref mut debug) = self.debug {
                     debug.run(name, &inputs, &state, RunMode::Resume);
@@ -220,7 +228,7 @@ impl Context for DataKitFilter {
             }
         }
 
-        self.run_nodes();
+        self.run_nodes(HttpCallResponse);
 
         self.resume_http_request();
     }
@@ -237,7 +245,7 @@ impl HttpContext for DataKitFilter {
             self.set_headers_data(vec, "request_headers");
         }
 
-        self.run_nodes()
+        self.run_nodes(HttpRequestHeaders)
     }
 
     fn on_http_request_body(&mut self, body_size: usize, eof: bool) -> Action {
@@ -249,7 +257,7 @@ impl HttpContext for DataKitFilter {
             }
         }
 
-        let action = self.run_nodes();
+        let action = self.run_nodes(HttpRequestBody);
 
         if self.do_service_request_headers {
             if let Some(payload) = self.data.first_input_for("service_request_headers", None) {
@@ -275,7 +283,7 @@ impl HttpContext for DataKitFilter {
             self.set_headers_data(vec, "service_response_headers");
         }
 
-        let action = self.run_nodes();
+        let action = self.run_nodes(HttpResponseHeaders);
 
         if self.do_response_headers {
             if let Some(payload) = self.data.first_input_for("response_headers", None) {
@@ -313,7 +321,7 @@ impl HttpContext for DataKitFilter {
             }
         }
 
-        let action = self.run_nodes();
+        let action = self.run_nodes(HttpResponseBody);
 
         if self.do_response_body {
             if let Some(payload) = self.data.first_input_for("response_body", None) {

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -296,9 +296,11 @@ impl HttpContext for DataKitFilter {
             if let Some(payload) = self.data.first_input_for("response_body", None) {
                 let content_length = payload.len().map(|n| n.to_string());
                 self.set_http_response_header("Content-Length", content_length.as_deref());
-                self.set_http_response_header("Content-Encoding", None);
                 self.set_http_response_header("Content-Type", payload.content_type());
+            } else {
+                self.set_http_response_header("Content-Length", None);
             }
+            self.set_http_response_header("Content-Encoding", None);
         }
 
         if self.debug.is_some() {

--- a/src/nodes.rs
+++ b/src/nodes.rs
@@ -25,6 +25,14 @@ pub trait Node {
 
 pub trait NodeConfig {
     fn as_any(&self) -> &dyn Any;
+
+    fn default_inputs(&self) -> Option<Vec<String>> {
+        None
+    }
+
+    fn default_outputs(&self) -> Option<Vec<String>> {
+        None
+    }
 }
 
 pub trait NodeFactory: Send {

--- a/src/nodes.rs
+++ b/src/nodes.rs
@@ -4,7 +4,7 @@ use std::any::Any;
 use std::collections::BTreeMap;
 use std::sync::{Mutex, OnceLock};
 
-use crate::data::{Payload, State, State::*};
+use crate::data::{Input, State, State::*};
 
 pub mod call;
 pub mod jq;
@@ -14,11 +14,11 @@ pub mod template;
 pub type NodeMap = BTreeMap<String, Box<dyn Node>>;
 
 pub trait Node {
-    fn run(&self, _ctx: &dyn HttpContext, _inputs: &[Option<&Payload>]) -> State {
+    fn run(&self, _ctx: &dyn HttpContext, _input: &Input) -> State {
         Done(None)
     }
 
-    fn resume(&self, _ctx: &dyn HttpContext, _inputs: &[Option<&Payload>]) -> State {
+    fn resume(&self, _ctx: &dyn HttpContext, _input: &Input) -> State {
         Done(None)
     }
 }

--- a/src/nodes/call.rs
+++ b/src/nodes/call.rs
@@ -8,7 +8,7 @@ use url::Url;
 
 use crate::config::get_config_value;
 use crate::data;
-use crate::data::{Payload, State, State::*};
+use crate::data::{Input, Payload, State, State::*};
 use crate::nodes::{Node, NodeConfig, NodeFactory};
 
 #[derive(Clone, Debug)]
@@ -33,11 +33,11 @@ pub struct Call {
 }
 
 impl Node for Call {
-    fn run(&self, ctx: &dyn HttpContext, inputs: &[Option<&Payload>]) -> State {
+    fn run(&self, ctx: &dyn HttpContext, input: &Input) -> State {
         log::debug!("call: run");
 
-        let body = inputs.first().unwrap_or(&None);
-        let headers = inputs.get(1).unwrap_or(&None);
+        let body = input.data.first().unwrap_or(&None);
+        let headers = input.data.get(1).unwrap_or(&None);
 
         let call_url = match Url::parse(self.config.url.as_str()) {
             Ok(u) => u,
@@ -89,7 +89,7 @@ impl Node for Call {
         }
     }
 
-    fn resume(&self, ctx: &dyn HttpContext, _inputs: &[Option<&Payload>]) -> State {
+    fn resume(&self, ctx: &dyn HttpContext, _inputs: &Input) -> State {
         log::debug!("call: resume");
 
         let r = if let Some(body) = ctx.get_http_call_response_body(0, usize::MAX) {

--- a/src/nodes/jq.rs
+++ b/src/nodes/jq.rs
@@ -7,7 +7,7 @@ use std::any::Any;
 use std::collections::BTreeMap;
 
 use crate::config::get_config_value;
-use crate::data::{Payload, State};
+use crate::data::{Input, Payload, State};
 use crate::nodes::{Node, NodeConfig, NodeFactory};
 
 #[derive(Clone, Debug)]
@@ -175,8 +175,8 @@ impl Jq {
 }
 
 impl Node for Jq {
-    fn run(&self, _ctx: &dyn HttpContext, inputs: &[Option<&Payload>]) -> State {
-        match self.exec(inputs) {
+    fn run(&self, _ctx: &dyn HttpContext, input: &Input) -> State {
+        match self.exec(input.data) {
             Ok(mut results) => {
                 State::Done(match results.len() {
                     // empty

--- a/src/nodes/response.rs
+++ b/src/nodes/response.rs
@@ -19,6 +19,10 @@ impl NodeConfig for ResponseConfig {
     fn as_any(&self) -> &dyn Any {
         self
     }
+
+    fn default_outputs(&self) -> Option<Vec<String>> {
+        Some(vec!["response_body".to_string()])
+    }
 }
 
 #[derive(Clone)]

--- a/src/nodes/response.rs
+++ b/src/nodes/response.rs
@@ -32,10 +32,11 @@ pub struct Response {
 
 impl Node for Response {
     fn run(&self, ctx: &dyn HttpContext, input: &Input) -> State {
-        let body = input.data.first().unwrap_or(&None);
-        let headers = input.data.get(1).unwrap_or(&None);
+        let config = &self.config;
+        let body = input.data.first().unwrap_or(&None).as_deref();
+        let headers = input.data.get(1).unwrap_or(&None).as_deref();
 
-        let mut headers_vec = data::to_pwm_headers(*headers);
+        let mut headers_vec = data::to_pwm_headers(headers);
 
         if let Some(payload) = body {
             if let Some(content_type) = payload.content_type() {
@@ -43,7 +44,7 @@ impl Node for Response {
             }
         }
 
-        let body_slice = match data::to_pwm_body(*body) {
+        let body_slice = match data::to_pwm_body(body) {
             Ok(slice) => slice,
             Err(e) => return Fail(Some(Payload::Error(e))),
         };
@@ -53,7 +54,7 @@ impl Node for Response {
                 ctx.set_http_response_body(0, b.len(), &b);
             }
         } else {
-            ctx.send_http_response(self.config.status, headers_vec, body_slice.as_deref());
+            ctx.send_http_response(config.status, headers_vec, body_slice.as_deref());
         }
 
         Done(None)

--- a/src/nodes/response.rs
+++ b/src/nodes/response.rs
@@ -5,7 +5,7 @@ use std::collections::BTreeMap;
 
 use crate::config::get_config_value;
 use crate::data;
-use crate::data::{Payload, State, State::*};
+use crate::data::{Input, Payload, State, State::*};
 use crate::nodes::{Node, NodeConfig, NodeFactory};
 
 #[derive(Clone, Debug)]
@@ -31,9 +31,9 @@ pub struct Response {
 }
 
 impl Node for Response {
-    fn run(&self, ctx: &dyn HttpContext, inputs: &[Option<&Payload>]) -> State {
-        let body = inputs.first().unwrap_or(&None);
-        let headers = inputs.get(1).unwrap_or(&None);
+    fn run(&self, ctx: &dyn HttpContext, input: &Input) -> State {
+        let body = input.data.first().unwrap_or(&None);
+        let headers = input.data.get(1).unwrap_or(&None);
 
         let mut headers_vec = data::to_pwm_headers(*headers);
 

--- a/src/nodes/template.rs
+++ b/src/nodes/template.rs
@@ -5,7 +5,7 @@ use std::any::Any;
 use std::collections::BTreeMap;
 
 use crate::config::get_config_value;
-use crate::data::{Payload, State};
+use crate::data::{Input, Payload, State};
 use crate::nodes::{Node, NodeConfig, NodeFactory};
 
 #[derive(Clone, Debug)]
@@ -46,13 +46,11 @@ impl Template<'_> {
 }
 
 impl Node for Template<'_> {
-    fn run(&self, _ctx: &dyn HttpContext, inputs: &[Option<&Payload>]) -> State {
-        log::debug!("template: run - inputs: {:?}", inputs);
-
+    fn run(&self, _ctx: &dyn HttpContext, input: &Input) -> State {
         let mut vs = Vec::new();
         let mut data = BTreeMap::new();
 
-        for (input_name, input) in self.config.inputs.iter().zip(inputs.iter()) {
+        for (input_name, input) in self.config.inputs.iter().zip(input.data.iter()) {
             match input {
                 Some(Payload::Json(value)) => {
                     data.insert(input_name, value);


### PR DESCRIPTION
If the `response` node needs the `service_response_body` input, it can only be triggered at the `HttpResponseBody` phase (which in Nginx means `body_filter`). This means that the headers have already been sent, meaning we can't use `ctx.send_http_response`.

By detecting this late phase, we degrade the behavior of the node and only set the response body. More specifically, in those cases the `response` node cannot set headers or a custom status.

We issue a one-time(-per-worker) warning if the user configuration triggers this degraded behavior while attempting to use unsupported parameters (e.g. setting a custom status).

Fixes #11.