### PR TITLE
fix: send a default error response if any node fails

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -253,3 +253,23 @@ impl Data {
         None
     }
 }
+
+#[derive(Serialize)]
+struct ErrorMessage<'a> {
+    message: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    request_id: Option<String>,
+}
+
+pub fn to_json_error_body(message: &str, request_id: Option<Vec<u8>>) -> String {
+    serde_json::to_value(ErrorMessage {
+        message,
+        request_id: match request_id {
+            Some(vec) => std::str::from_utf8(&vec).map(|v| v.to_string()).ok(),
+            None => None,
+        },
+    })
+    .ok()
+    .map(|v| v.to_string())
+    .expect("JSON error object")
+}


### PR DESCRIPTION
Rather than ignoring failures, stop executing further nodes. (In the future, we will have error catching and handling, but for now it is better to stop the pipeline than to continue proxying silently with an incomplete execution.)

The default behavior is to trigger an error response. If debug tracing is enabled, the response error is not generated, so that the execution trace can be printed in the response body.